### PR TITLE
Fix missing commas in the json response returned by /queues/json

### DIFF
--- a/src/bruce/web_request_handler.cc
+++ b/src/bruce/web_request_handler.cc
@@ -357,6 +357,7 @@ void TWebRequestHandler::HandleQueueStatsRequestJson(std::ostream &os,
         }
 
         os << ind2 << "}";
+        first_time = false;
       }
 
       os << std::endl;


### PR DESCRIPTION
This PR fixes missing commas separating list elements in the /queues/json response:

```
$ curl localhost:9090/queues/json
{
    "now": 1424884299,
    "pid": 10119,
    "version": "1.0.9.2.g69d1bdf",
    "sending": [        {
            "topic": "topic1",
            "batch": 1000,
            "send_wait": 0,
            "ack_wait": 0
        }        {
            "topic": "topic2",
            "batch": 1000,
            "send_wait": 0,
            "ack_wait": 0
        }
    ],
    "new": 0
}
```

Perhaps using Boost.PropertyTree can make json generation less error prone.
