### PR TITLE
Fix warn_unused_result warnings (errors)

### DIFF
--- a/src/bruce/debug/debug_setup.cc
+++ b/src/bruce/debug/debug_setup.cc
@@ -149,16 +149,16 @@ void TDebugSetup::SetDebugTopics(
 
 void TDebugSetup::TruncateDebugFiles() {
   assert(this);
-  truncate(GetLogPath(TLogId::MSG_RECEIVE).c_str(), 0);
-  truncate(GetLogPath(TLogId::MSG_SEND).c_str(), 0);
-  truncate(GetLogPath(TLogId::MSG_GOT_ACK).c_str(), 0);
+  IfLt0(truncate(GetLogPath(TLogId::MSG_RECEIVE).c_str(), 0));
+  IfLt0(truncate(GetLogPath(TLogId::MSG_SEND).c_str(), 0));
+  IfLt0(truncate(GetLogPath(TLogId::MSG_GOT_ACK).c_str(), 0));
 }
 
 void TDebugSetup::CreateDebugDir() {
   assert(this);
   std::string cmd("/bin/mkdir -p ");
   cmd += DebugDir;
-  std::system(cmd.c_str());
+  IfLt0(std::system(cmd.c_str()));
 }
 
 static void SettingsFtruncate(const TDebugSetup::TSettings &settings) {

--- a/src/bruce/discard_file_logger.cc
+++ b/src/bruce/discard_file_logger.cc
@@ -86,7 +86,7 @@ static void CreateDir(const char *dir) {
   assert(dir);
   std::string cmd("/bin/mkdir -p ");
   cmd += dir;
-  std::system(cmd.c_str());
+  IfLt0(std::system(cmd.c_str()));
 }
 
 TDiscardFileLogger::TDiscardFileLogger()

--- a/src/server/daemonize.cc
+++ b/src/server/daemonize.cc
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 
 #include <base/os_error.h>
+#include <base/error_utils.h>
 
 using namespace std;
 using namespace Base;
@@ -101,12 +102,12 @@ pid_t Server::Daemonize() {
       close(2);
       /* Reroute stdin and stdout to dev/null. */
       int dev_null = open("/dev/null", O_RDWR);
-      (void) dup(dev_null);
-      (void) dup(dev_null);
+      IfLt0(dup(dev_null));
+      IfLt0(dup(dev_null));
       /* Set newly created file permissions. */
       umask(0);
       /* Move to the root dir. */
-      (void) chdir("/");
+      IfLt0(chdir("/"));
       /* Keep signals away. */
       DefendAgainstSignals();
     }


### PR DESCRIPTION
Encountered on Ubuntu 14.04.1 LTS with:
- gcc 4.8.2-19ubuntu1
- libc6 2.19-0ubuntu6.5

which due to `-Werror` prevents bruce to compile.
