### PR TITLE
Remove unnecessary flag which breaks building on Ubuntu

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -167,9 +167,9 @@ def set_debug_options():
 
 def set_release_options():
     env.AppendUnique(CCFLAGS=['-O2', '-DNDEBUG', '-Wno-unused',
-                              '-Wno-unused-parameter', '-flto',
+                              '-Wno-unused-parameter',
                               '-fvisibility=hidden'])
-    env.AppendUnique(LINKFLAGS=['-flto', '-rdynamic'])
+    env.AppendUnique(LINKFLAGS=['-rdynamic'])
 
 
 # Append 'mode' specific environment variables.


### PR DESCRIPTION
With the -flto flag compiling on ubuntu-precise-64 3.2.0-92-virtual with g++ Ubuntu 4.9.2-0ubuntu1~12.04) 4.9.2, results in an error: 

```
lto-wrapper: malformed COLLECT_GCC_OPTIONS
/usr/bin/ld: lto-wrapper failed
collect2: error: ld returned 1 exit status
scons: *** [out/release/bruce/bruce] Error 1
```

According to the g++ documentation this flag is ignored; nevertheless it causes this error.
